### PR TITLE
Add docs about auto-restart and checks

### DIFF
--- a/sdk/pebble.md
+++ b/sdk/pebble.md
@@ -234,8 +234,6 @@ The `backoff-factor` must be greater than or equal to 1.0. If the factor is set 
 
 Just before delaying, a small random time jitter of 0-10% of the delay is added (the current delay is not updated). For example, if the current delay value is 2 seconds, the actual delay will be between 2.0 and 2.2 seconds.
 
-A charm can find the total number of times Pebble has restarted a service using the `restarts` field in the [`ServiceInfo`](https://ops.readthedocs.io/en/latest/#ops.pebble.ServiceInfo) object returned by the [`Container.get_service`](https://ops.readthedocs.io/en/latest/#ops.model.Container.get_service) method.
-
 
 <h2 id="heading--health-checks">Health checks</h2>
 

--- a/sdk/pebble.md
+++ b/sdk/pebble.md
@@ -296,9 +296,9 @@ As of Juju version TODO:TBD, Pebble includes an HTTP `/v1/health` endpoint that 
 
 Each check can specify a `level` of "alive" or "ready". These have semantic meaning: "alive" means the check or the service it's connected to is up and running; "ready" means it's properly accepting network traffic. These correspond to Kubernetes ["liveness" and "readiness" probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).
 
-Ready implies alive, and not alive implies not ready. If you've configured an "alive" check but no "ready" check and the "alive" check is unhealthy, Pebble indicates that the "ready" check is unhealthy too.
-
 When Juju creates a sidecar charm container, it initializes the Kubernetes liveness and readiness probes to hit the `/v1/health` endpoint with `?level=alive` and `?level=ready` filters, respectively.
+
+Ready implies alive, and not alive implies not ready. If you've configured an "alive" check but no "ready" check, and the "alive" check is unhealthy, `/v1/health?level=ready` will report unhealthy as well, and the Kubernetes readiness probe will act on that.
 
 If there are no checks configured, Pebble returns HTTP 200 so the liveness and readiness probes are successful by default. To use this feature, you must explicitly create checks with `level: alive` or `level: ready` in the layer configuration.
 

--- a/sdk/pebble.md
+++ b/sdk/pebble.md
@@ -305,7 +305,7 @@ When Juju creates a sidecar charm container, it initializes the Kubernetes liven
 If there are no checks configured, Pebble returns HTTP 200 so the liveness and readiness probes are successful by default. To use this feature, you must explicitly create checks with `level: alive` or `level: ready` in the layer configuration.
 
 
-<h2 id="heading--files-api">The Files API</h2>
+ <a href="#heading--the-files-api"><h2 id="heading--the-files-api">The files API</h2></a>
 
 Pebble's files API allows charm authors to read and write files on the workload container. You can write files ("push"), read files ("pull"), list files in a directory, make directories, and delete files or directories.
 

--- a/sdk/pebble.md
+++ b/sdk/pebble.md
@@ -242,7 +242,7 @@ Just before delaying, a small random time jitter of 0-10% of the delay is added 
 
 <a href="#heading--health-checks"><h2 id="heading--health-checks">Health checks</h2></a>
 
-From Juju version TODO:TBD, Pebble supports adding custom health checks: first, to allow Pebble itself to restart services when certain checks fail, and second, to allow Kubernetes to restart containers when specified checks fail.
+From Juju version 2.9.26, Pebble supports adding custom health checks: first, to allow Pebble itself to restart services when certain checks fail, and second, to allow Kubernetes to restart containers when specified checks fail.
 
 Each check can be one of three types. The types and their success criteria are:
 
@@ -297,7 +297,7 @@ services:
 
 <a href="#heading--health-endpoint-and-probes"><h3 id="heading--health-endpoint-and-probes">Health endpoint and probes</h3></a>
 
-As of Juju version TODO:TBD, Pebble includes an HTTP `/v1/health` endpoint that allows a user to query the health of configured checks, optionally filtered by check level with the query string `?level=<level>` This endpoint returns an HTTP 200 status if the checks are healthy, HTTP 502 otherwise.
+As of Juju version 2.9.26, Pebble includes an HTTP `/v1/health` endpoint that allows a user to query the health of configured checks, optionally filtered by check level with the query string `?level=<level>` This endpoint returns an HTTP 200 status if the checks are healthy, HTTP 502 otherwise.
 
 Each check can specify a `level` of "alive" or "ready". These have semantic meaning: "alive" means the check or the service it's connected to is up and running; "ready" means it's properly accepting network traffic. These correspond to Kubernetes ["liveness" and "readiness" probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).
 

--- a/sdk/pebble.md
+++ b/sdk/pebble.md
@@ -20,6 +20,11 @@ The rest of this document provides details of how a charm interacts with the wor
     - [Fetch service status](#heading--fetch-service-status)
     - [Send signals to services](#heading--send-signals-to-services)
     - [View service logs](#heading--view-service-logs)
+- [Service auto-restart](#heading--service-auto-restart)
+- [Health checks](#heading--health-checks)
+    - [Check configuration](#heading--check-configuration)
+    - [Checks auto-restart](#heading--checks-auto-restart)
+    - [Health endpoint and probes](#heading--health-endpoint-and-probes)
 - [The files API](#heading--the-files-api)
     - [Push](#heading--push)
     - [Pull](#heading--pull)
@@ -235,7 +240,7 @@ The `backoff-factor` must be greater than or equal to 1.0. If the factor is set 
 Just before delaying, a small random time jitter of 0-10% of the delay is added (the current delay is not updated). For example, if the current delay value is 2 seconds, the actual delay will be between 2.0 and 2.2 seconds.
 
 
-<h2 id="heading--health-checks">Health checks</h2>
+<a href="#heading--health-checks"><h2 id="heading--health-checks">Health checks</h2></a>
 
 From Juju version TODO:TBD, Pebble supports adding custom health checks: first, to allow Pebble itself to restart services when certain checks fail, and second, to allow Kubernetes to restart containers when specified checks fail.
 
@@ -245,7 +250,7 @@ Each check can be one of three types. The types and their success criteria are:
 * `tcp`: opening the given TCP port must be successful.
 * `exec`: executing the specified command must yield a zero exit code.
 
-<h3 id="heading--check-configuration">Check configuration</h3>
+<a href="#heading--check-configuration"><h3 id="heading--check-configuration">Check configuration</h3></a>
 
 Checks are configured in the layer configuration using the top-level field `checks`. Here's an example showing the three different types of checks:
 
@@ -278,7 +283,7 @@ A check is considered healthy until it's had `threshold` errors in a row (the de
 
 See the [layer specification](https://github.com/canonical/pebble#layer-specification) for more details about the fields and options for different types of checks.
 
-<h3 id="heading--checks-auto-restart">Checks auto-restart</h3>
+<a href="#heading--checks-auto-restart"><h3 id="heading--checks-auto-restart">Checks auto-restart</h3></a>
 
 To enable Pebble auto-restart behavior based on a check, use the `on-check-failure` map in the service configuration. For example, to restart the "server" service when the "test" check fails, use the following configuration:
 
@@ -290,7 +295,7 @@ services:
             test: restart   # can also be "shutdown" or "ignore" (the default)
 ```
 
-<h3 id="heading--health-endpoint-and-probes">Health endpoint and probes</h3>
+<a href="#heading--health-endpoint-and-probes"><h3 id="heading--health-endpoint-and-probes">Health endpoint and probes</h3></a>
 
 As of Juju version TODO:TBD, Pebble includes an HTTP `/v1/health` endpoint that allows a user to query the health of configured checks, optionally filtered by check level with the query string `?level=<level>` This endpoint returns an HTTP 200 status if the checks are healthy, HTTP 502 otherwise.
 

--- a/sdk/pebble.md
+++ b/sdk/pebble.md
@@ -256,7 +256,7 @@ checks:
         level: alive  # optional, but required for liveness/readiness probes
         period: 10s   # this is the default
         timeout: 3s   # this is the default
-        failures: 3   # this is the default
+        threshold: 3  # this is the default
         exec:
             command: service nginx status
 
@@ -274,7 +274,7 @@ checks:
 
 Each check is performed with the specified `period` (the default is 10 seconds apart), and is considered an error if a `timeout` happens before the check responds -- for example, before the HTTP request is complete or before the command finishes executing.
 
-A check is considered healthy until it's had `failures` errors in a row (the default is 3). At that point, the `on-check-failure` action will be triggered, and the health endpoint will return an error response (both are discussed below). When the check succeeds again, the failure count is reset.
+A check is considered healthy until it's had `threshold` errors in a row (the default is 3). At that point, the `on-check-failure` action will be triggered, and the health endpoint will return an error response (both are discussed below). When the check succeeds again, the failure count is reset.
 
 See the [layer specification](https://github.com/canonical/pebble#layer-specification) for more details about the fields and options for different types of checks.
 

--- a/sdk/pebble.md
+++ b/sdk/pebble.md
@@ -215,8 +215,8 @@ services:
         command: python3 app.py
 
         # auto-restart options (showing defaults)
-        on-success: restart   # can also be "halt" or "ignore"
-        on-failure: restart   # can also be "halt" or "ignore"
+        on-success: restart   # can also be "shutdown" or "ignore"
+        on-failure: restart   # can also be "shutdown" or "ignore"
         backoff-delay: 500ms
         backoff-factor: 2.0
         backoff-limit: 30s
@@ -225,7 +225,7 @@ services:
 The `on-success` action is performed if the service exits with a zero exit code, and the `on-failure` action is performed if it exits with a nonzero code. The actions are defined as follows:
 
 * `restart`: automatically restart the service after the current backoff delay. This is the default.
-* `halt`: terminate the Pebble server. Because Pebble is the container's "PID 1" process, this will cause the container to terminate -- useful if you want Kubernetes to restart the container.
+* `shutdown`: shut down the Pebble server. Because Pebble is the container's "PID 1" process, this will cause the container to terminate -- useful if you want Kubernetes to restart the container.
 * `ignore`: do nothing (apart from logging the failure).
 
 The backoff delay between restarts is calculated using an exponential backoff: `next = current * backoff_factor`, with `current` starting at the configured `backoff-delay`. If `next` is greater than `backoff-limit`, it is capped at `backoff-limit`. With the defaults, the delays (in seconds) will be: 0.5, 1, 2, 4, 8, 16, 30, 30, and so on.
@@ -289,7 +289,7 @@ services:
     server:
         override: merge
         on-check-failure:
-            test: restart   # can also be "halt" or "ignore" (the default)
+            test: restart   # can also be "shutdown" or "ignore" (the default)
 ```
 
 <h3 id="heading--health-endpoint-and-probes">Health endpoint and probes</h3>


### PR DESCRIPTION
These are updates to the [How to interact with Pebble](https://juju.is/docs/sdk/pebble) document ([Discourse original here](https://discourse.charmhub.io/t/how-to-interact-with-pebble/4554)) for the new Pebble auto-restart and health checks features.

Implementation for these features is in https://github.com/canonical/pebble/pull/85 and https://github.com/canonical/pebble/pull/86.