### PR TITLE
Update start/stop; rename autostart to replan; add send-signal and logging

### DIFF
--- a/sdk/pebble.md
+++ b/sdk/pebble.md
@@ -99,6 +99,15 @@ class MyCharm(CharmBase):
                 container.start('mysql')
 ```
 
+<h3 id="heading--sending-signals">Sending signals to services</h3>
+
+From Juju version 2.9.22, you can use the [`Container.send_signal`](https://ops.readthedocs.io/en/latest/#ops.model.Container.send_signal) method to send a signal to one or more services. For example, to send `SIGHUP` to the hypothetical "nginx" and "redis" services:
+
+```python
+container.send_signal('SIGHUP', 'nginx', 'redis')
+```
+
+This will raise an `APIError` if any of the services are not in the plan or are not currently running.
 
 <h2 id="heading--configuration">Pebble layer configuration</h2>
 
@@ -107,6 +116,8 @@ Pebble services are [configured by means of layers](https://github.com/canonical
 When a workload container is created and Pebble starts up, it looks in `/var/lib/pebble/default/layers` (if that exists) for configuration layers already present in the container image, such as `001-layer.yaml`. If there are existing layers there, that becomes the starting configuration, otherwise Pebble is happy to start with an empty configuration, meaning no services.
 
 In the latter case, Pebble is configured dynamically via the API by adding layers at runtime.
+
+See the [layer specification](https://github.com/canonical/pebble#layer-specification) for more details.
 
 <h3 id="heading--add-layer">Add a configuration layer</h3>
 

--- a/sdk/pebble.md
+++ b/sdk/pebble.md
@@ -18,6 +18,8 @@ In the context of Juju sidecar charms, Pebble is run with the `--hold` argument,
 
 <h3 id="heading--autostart">Autostart</h3>
 
+TODO: rework "autostart" section to use "replan"
+
 To start all the services that are marked as `startup: enabled` in the configuration plan, call [`Container.autostart`](https://ops.readthedocs.io/en/latest/#ops.model.Container.autostart). For example (taken from the [snappass-test](https://github.com/benhoyt/snappass-test/blob/master/src/charm.py) charm):
 
 ```python
@@ -108,6 +110,11 @@ container.send_signal('SIGHUP', 'nginx', 'redis')
 ```
 
 This will raise an `APIError` if any of the services are not in the plan or are not currently running.
+
+<h3 id="heading--service-logs">Service logs</h3>
+
+TODO: add new section about service logs, how Juju runs in `--verbose`, etc
+
 
 <h2 id="heading--configuration">Pebble layer configuration</h2>
 

--- a/sdk/pebble.md
+++ b/sdk/pebble.md
@@ -72,6 +72,12 @@ class MyCharm(CharmBase):
                 # handle Pebble errors
 ```
 
+It's not an error to start a service that's already started, or stop one that's already stopped. These actions are *idempotent*, meaning they can safely be performed more than once, and the service will remain in the same state.
+
+When Pebble starts a service, Pebble waits one second to ensure the process doesn't exit too quickly -- if the process exits within one second, the start operation raises an error and the service remains stopped.
+
+To stop a service, Pebble first sends `SIGTERM` to the service's process group to try to stop the service gracefully. If the process has not exited after 5 seconds, Pebble sends `SIGKILL` to the process group. If the process still doesn't exit after another 5 seconds, the stop operation raises an error. If the process exits any time before the 10 seconds have elapsed, the stop operation succeeds.
+
 <h3 id="heading--get-services">Fetch service status</h3>
 
 You can use the [`get_service`](https://ops.readthedocs.io/en/latest/#ops.model.Container.get_service) and [`get_services`](https://ops.readthedocs.io/en/latest/#ops.model.Container.get_services) methods to fetch the current status of one service or multiple services, respectively. The returned [`ServiceInfo`](https://ops.readthedocs.io/en/latest/#ops.pebble.ServiceInfo) objects provide a `status` attribute with various states, or you can use the [`ServiceInfo.is_running`](https://ops.readthedocs.io/en/latest/#ops.pebble.ServiceInfo.is_running) method.


### PR DESCRIPTION
Add more details about how start/stop actually works. The "autostart" command is deprecated now that we have "replan", so describe that instead. Also add a section about how logging works and how to access logs via `kubectl`, as well as a section about `send_signal`.