### PR TITLE
Add "Pebble Notices" section to Pebble doc

### DIFF
--- a/sdk/container-pebble-custom-notice-event.md
+++ b/sdk/container-pebble-custom-notice-event.md
@@ -1,0 +1,16 @@
+> <small> [Event](/t/6361) > [List of events](/t/6657) > [Lifecycle events](/t/4455) > `<container>-pebble-custom-notice`</small>
+>
+> Source: [`ops.PebbleCustomNoticeEvent`](https://ops.readthedocs.io/en/latest/index.html#ops.PebbleCustomNoticeEvent)
+
+<!--
+> - [How to operate workload containers](/t/6542)
+> - [Interact with Pebble](/t/4554)
+-->
+
+Juju emits the `<container>-pebble-custom-notice` event when a Pebble notice of type "custom" occurs for the first time or repeats. There is one `<container>-pebble-custom-notice` event for each container defined in `metadata.yaml`. This event allows the charm to respond to custom events that happen in the workload container.
+
+[note] 
+This event is specific to Kubernetes sidecar charms and is only ever fired on Kubernetes deployments.
+[/note]
+
+To learn more about Pebble notices, and see an example of handling a custom notice, read the [full Pebble Notices documentation](/t/4554#heading--custom-notices).

--- a/sdk/interact-with-pebble.md
+++ b/sdk/interact-with-pebble.md
@@ -835,7 +835,7 @@ ops.pebble.ExecError: non-zero exit code 143 executing ['sleep', '10']
 
 <a href="#heading--use-custom-notices-from-the-workload-container"><h2 id="heading--use-custom-notices-from-the-workload-container">Use custom notices from the workload container</h2></a>
 
-From version 3.4, Juju includes support for [Pebble Notices](https://github.com/canonical/pebble/#notices). Juju polls each container's Pebble server for new notices, and fires an event to the charm when a notice first occurs and each time it repeats.
+From version 3.4, Juju includes support for [Pebble Notices](https://github.com/canonical/pebble/#notices). Juju polls each workload container's Pebble server for new notices, and fires an event to the charm when a notice first occurs as well as each time it repeats.
 
 Each notice has a *type* and *key*, the combination of which uniquely identifies it. A notice's count of occurrences is incremented every time a notice with that type and key combination occurs.
 
@@ -853,20 +853,20 @@ pg_dump mydb >/tmp/mydb.sql
 pebble notify canonical.com/postgresql/backup-done path=/tmp/mydb.sql
 ```
 
-The first argument to `pebble notify` is the key, which must be in the format `<domain>/<path>`. The caller can optionally provide a map data arguments in `<name>=<value>` format; this example shows a single data argument named `path`.
+The first argument to `pebble notify` is the key, which must be in the format `<domain>/<path>`. The caller can optionally provide map data arguments in `<name>=<value>` format; this example shows a single data argument named `path`.
 
 The `pebble notify` command has an optional `--repeat-after` flag, which tells Pebble to only allow the notice to repeat after the specified duration (the default is to repeat for every occurrence). If the caller says `--repeat-after=1h`, Pebble will prevent the notice with the same type and key from repeating within an hour -- useful to avoid the charm waking up too often when a notice occcurs frequently.
 
 
 <a href="#heading--responding-to-a-notice"><h3 id="heading--responding-to-a-notice">Responding to a notice</h3></a>
 
-To have the charm respond to a notice occurring, observe the `pebble-custom-notice` event and switch on the notice's `key`:
+To have the charm respond to a notice, observe the `pebble_custom_notice` event and switch on the notice's `key`:
 
 ```python
 class PostgresCharm(ops.CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-        # Note that 'db' is the workload container's name
+        # Note that "db" is the workload container's name
         self.framework.observe(self.on["db"].pebble_custom_notice, self._on_pebble_custom_notice)
 
     def _on_pebble_custom_notice(self, event: ops.PebbleCustomNoticeEvent) -> None:
@@ -893,7 +893,7 @@ A charm can also query for notices using the following two `Container` methods:
 
 <a href="#heading--testing-with-notices"><h3 id="testing-with-notices">Testing with notices</h3></a>
 
-To test charms that use Pebble Notices, use the [`Harness.pebble_notify`](https://ops.readthedocs.io/en/latest/#ops.testing.Harness.pebble_notify) method to simulate recording a notice with the given details. For example, to simulate the "backup-done" notice handled above, the charm tests might do the following:
+To test charms that use Pebble Notices, use the [`Harness.pebble_notify`](https://ops.readthedocs.io/en/latest/#ops.testing.Harness.pebble_notify) method to simulate recording a notice with the given details. For example, to simulate the "backup-done" notice handled above, the charm tests could do the following:
 
 ```python
 class TestCharm(unittest.TestCase):

--- a/sdk/interact-with-pebble.md
+++ b/sdk/interact-with-pebble.md
@@ -844,7 +844,7 @@ Each notice has a *type* and *key*, the combination of which uniquely identifies
 
 Currently, the only supported notice type is "custom". These are custom notices recorded by a user of Pebble; in future, other notice types may be recorded by Pebble itself. When a custom notice occurs, Juju fires a [`PebbleCustomNoticeEvent`](https://ops.readthedocs.io/en/latest/#ops.PebbleCustomNoticeEvent) event whose [`workload`](https://ops.readthedocs.io/en/latest/#ops.WorkloadEvent.workload) attribute is set to the relevant container.
 
-Custom notices allow the workload to wake up the charm when something interesting happens on the workload, for example, when a PostgreSQL backup process finishes, or some kind of alert occurs.
+Custom notices allow the workload to wake up the charm when something interesting happens with the workload, for example, when a PostgreSQL backup process finishes, or some kind of alert occurs.
 
 To record a custom notice, use the `pebble notify` CLI command. For example, the workload might have a script to back up the database and then record a notice:
 
@@ -864,10 +864,10 @@ To have the charm respond to a notice, observe the `pebble_custom_notice` event 
 
 ```python
 class PostgresCharm(ops.CharmBase):
-    def __init__(self, *args):
-        super().__init__(*args)
+    def __init__(self, framework: ops.Framework):
+        super().__init__(framework)
         # Note that "db" is the workload container's name
-        self.framework.observe(self.on["db"].pebble_custom_notice, self._on_pebble_custom_notice)
+        framework.observe(self.on["db"].pebble_custom_notice, self._on_pebble_custom_notice)
 
     def _on_pebble_custom_notice(self, event: ops.PebbleCustomNoticeEvent) -> None:
         if event.notice.key == "canonical.com/postgresql/backup-done":

--- a/sdk/interact-with-pebble.md
+++ b/sdk/interact-with-pebble.md
@@ -850,7 +850,7 @@ To record a custom notice, use the `pebble notify` CLI command. For example, the
 
 ```sh
 pg_dump mydb >/tmp/mydb.sql
-pebble notify canonical.com/postgresql/backup-done path=/tmp/mydb.sql
+/charm/bin/pebble notify canonical.com/postgresql/backup-done path=/tmp/mydb.sql
 ```
 
 The first argument to `pebble notify` is the key, which must be in the format `<domain>/<path>`. The caller can optionally provide map data arguments in `<name>=<value>` format; this example shows a single data argument named `path`.


### PR DESCRIPTION
This PR adds a section about "Pebble Notices" to [this doc](https://juju.is/docs/sdk/interact-with-pebble), with charm and test examples.

It also adds a very basic `pebble-custom-notice` event page, based on the [pebble-ready one](https://juju.is/docs/sdk/container-name-pebble-ready-event).